### PR TITLE
check markdown images, ensure parent is File before referencing dir (…

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -149,6 +149,14 @@ module.exports = (
       return
     }
 
+    // since dir will be undefined on non-files
+    if (
+      markdownNode.parent &&
+      getNode(markdownNode.parent).internal.type !== `File`
+    ) {
+      return
+    }
+
     const imagePath = path.posix.join(
       getNode(markdownNode.parent).dir,
       image.url


### PR DESCRIPTION
…#3831)

* check markdown images, ensure parent is File before referencing dir

* add check for parent